### PR TITLE
完善任务分发平台与管理员后台

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # TEST_ddmx
-ceshi openai
+
+基于 Flask 的压力测试任务管理示例，提供普通用户和管理员两类界面。
+
+## 功能概览
+- 用户通过 Web 页面提交任务：支持多目标地址、选择 L4/L7 层级、并发数与测试时长滑动条、攻击方法自动联动下拉框。
+- 后端根据各子服务器上报的能力自动分配资源，能力不足时任务进入队列等待，资源释放后自动执行。
+- 任务列表页面实时展示执行进度和状态，并显示当前排队任务数量。
+- 管理员后台可查看/编辑子服务器信息（ID、IP、分组、最大并发、状态）。
+- 子服务器启动后调用管理端 `/agent/register` 自动上报自身能力。
+
+整体界面采用白底蓝色主调的简洁风格，按钮和进度条基于 Bootstrap，交互友好。
+
+## 使用方法
+1. 安装依赖：`pip install -r requirements.txt`
+2. 运行管理端：`python app.py`
+3. 浏览器访问 `http://localhost:5000`，使用默认密码登录
+   - 普通用户密码：`user123`
+   - 管理员密码：`admin123`
+4. 子服务器可运行 `worker.py`，并通过设置 `MANAGER_URL` 环境变量自动向管理端注册。
+
+攻击层级与方法绑定关系可在 `config.py` 的 `LAYER_METHODS` 中自定义。
+
+## 服务器端脚本 `worker.py`
+
+1. 安装依赖：`pip install Flask requests`
+2. （可选）环境变量
+   - `GO_EXEC`：Go 可执行文件路径，默认 `./go_task`
+   - `MANAGER_URL`：管理端地址，如 `http://manager:5000`
+   - `AGENT_ID`/`AGENT_GROUP`/`AGENT_MAX`：上报信息
+3. 启动脚本：`python worker.py`
+
+接口说明：
+- `POST /task`：接受 `{"link":"http://...","threads":2}`，将参数传给 Go 程序
+- `GET /status`：返回最近一次任务执行状态

--- a/app.py
+++ b/app.py
@@ -1,0 +1,192 @@
+from flask import Flask, render_template, request, redirect, url_for, session, jsonify, flash
+from werkzeug.security import check_password_hash
+import threading
+import time
+import uuid
+import os
+import config
+
+app = Flask(__name__)
+app.secret_key = os.environ.get('SECRET_KEY', os.urandom(24))
+app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SAMESITE='Lax')
+
+# --- 数据结构 ---
+servers = {s['id']: dict(s, used=0) for s in config.INIT_SERVERS}
+# 按分组统计总能力
+capacity = {'L4': 0, 'L7': 0}
+for s in servers.values():
+    capacity[s['group']] += s['max']
+used_capacity = {'L4': 0, 'L7': 0}
+
+tasks = {}  # id -> task info
+task_queue = []
+lock = threading.Lock()
+
+# --- 工具函数 ---
+def get_available(group):
+    return capacity.get(group, 0) - used_capacity.get(group, 0)
+
+def check_queue():
+    with lock:
+        for task in list(task_queue):
+            if get_available(task['layer']) >= task['concurrency']:
+                task_queue.remove(task)
+                _start_task(task)
+
+def _start_task(task):
+    used_capacity[task['layer']] += task['concurrency']
+    task['status'] = '执行中'
+    task['progress'] = 0
+    t = threading.Thread(target=run_task, args=(task,), daemon=True)
+    t.start()
+
+def run_task(task):
+    duration = task['duration']
+    start = time.time()
+    while True:
+        time.sleep(1)
+        elapsed = time.time() - start
+        with lock:
+            task['progress'] = min(100, int(elapsed / duration * 100))
+            if elapsed >= duration:
+                task['status'] = '已完成'
+                used_capacity[task['layer']] -= task['concurrency']
+                break
+    check_queue()
+
+# --- 路由 ---
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    error = None
+    if request.method == 'POST':
+        pwd = request.form.get('password', '')
+        if check_password_hash(config.ADMIN_PASSWORD_HASH, pwd):
+            session['logged_in'] = True
+            session['role'] = 'admin'
+            return redirect(url_for('index'))
+        elif check_password_hash(config.USER_PASSWORD_HASH, pwd):
+            session['logged_in'] = True
+            session['role'] = 'user'
+            return redirect(url_for('index'))
+        else:
+            error = '密码错误'
+    return render_template('login.html', error=error)
+
+@app.route('/logout')
+def logout():
+    session.clear()
+    return redirect(url_for('login'))
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if not session.get('logged_in'):
+        return redirect(url_for('login'))
+
+    max_concurrency = config.DEFAULT_MAX_CONCURRENCY
+    max_duration = config.DEFAULT_MAX_DURATION
+    layer_methods = config.LAYER_METHODS
+    message = None
+    if request.method == 'POST':
+        targets = [t.strip() for t in request.form.get('targets', '').splitlines() if t.strip()]
+        layer = request.form.get('layer')
+        concurrency = int(request.form.get('concurrency', 1))
+        duration = int(request.form.get('duration', 1))
+        method = request.form.get('method')
+        if not targets:
+            flash('目标地址不能为空')
+        elif layer not in layer_methods:
+            flash('攻击层级无效')
+        elif method not in layer_methods.get(layer, []):
+            flash('攻击方法无效')
+        else:
+            tid = str(uuid.uuid4())[:8]
+            task = {
+                'id': tid,
+                'targets': targets,
+                'layer': layer,
+                'concurrency': concurrency,
+                'duration': duration,
+                'method': method,
+                'status': '排队中',
+                'progress': 0
+            }
+            with lock:
+                tasks[tid] = task
+                if get_available(layer) >= concurrency:
+                    _start_task(task)
+                else:
+                    task_queue.append(task)
+            message = f'任务已提交，ID: {tid}'
+    return render_template('index.html',
+                           max_concurrency=max_concurrency,
+                           max_duration=max_duration,
+                           layer_methods=layer_methods,
+                           message=message,
+                           role=session.get('role'))
+
+@app.route('/tasks')
+def task_list():
+    if not session.get('logged_in'):
+        return redirect(url_for('login'))
+    return render_template('tasks.html', role=session.get('role'))
+
+@app.route('/api/tasks')
+def api_tasks():
+    if not session.get('logged_in'):
+        return jsonify([]), 401
+    with lock:
+        return jsonify(list(tasks.values()))
+
+@app.route('/admin')
+def admin():
+    if session.get('role') != 'admin':
+        return redirect(url_for('login'))
+    return render_template('admin.html')
+
+@app.route('/api/servers')
+def api_servers():
+    if session.get('role') != 'admin':
+        return jsonify([]), 401
+    with lock:
+        return jsonify(list(servers.values()))
+
+@app.route('/admin/server/<sid>/edit', methods=['POST'])
+def edit_server(sid):
+    if session.get('role') != 'admin':
+        return 'forbidden', 403
+    data = request.get_json() or {}
+    new_id = data.get('id', sid)
+    ip = data.get('ip', '')
+    group = data.get('group', 'L4')
+    maxc = int(data.get('max', 0))
+    status = data.get('status', 'offline')
+    with lock:
+        old = servers.pop(sid, None)
+        if not old:
+            return 'not found', 404
+        if old['status'] == 'online':
+            capacity[old['group']] -= old['max']
+        servers[new_id] = {'id': new_id, 'ip': ip, 'group': group, 'max': maxc, 'status': status, 'used': 0}
+        if status == 'online':
+            capacity[group] = capacity.get(group, 0) + maxc
+    check_queue()
+    return 'ok'
+
+@app.route('/agent/register', methods=['POST'])
+def agent_register():
+    data = request.get_json() or {}
+    sid = data.get('id') or str(uuid.uuid4())
+    ip = data.get('ip', '')
+    group = data.get('group', 'L4')
+    maxc = int(data.get('max', 0))
+    with lock:
+        if sid in servers:
+            # 更新能力
+            capacity[servers[sid]['group']] -= servers[sid]['max']
+        servers[sid] = {'id': sid, 'ip': ip, 'group': group, 'max': maxc, 'status': 'online', 'used': 0}
+        capacity[group] = capacity.get(group, 0) + maxc
+    check_queue()
+    return 'ok'
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/config.py
+++ b/config.py
@@ -1,0 +1,26 @@
+import os
+from werkzeug.security import generate_password_hash
+
+# 普通用户与管理员密码哈希，可通过环境变量覆盖
+ADMIN_PASSWORD_HASH = os.environ.get(
+    'ADMIN_PASSWORD_HASH', generate_password_hash('admin123')
+)
+USER_PASSWORD_HASH = os.environ.get(
+    'USER_PASSWORD_HASH', generate_password_hash('user123')
+)
+
+# 默认最大并发与时长，可根据实际资源动态调整
+DEFAULT_MAX_CONCURRENCY = 100
+DEFAULT_MAX_DURATION = 300
+
+# 初始服务器列表，实际使用中由子服务器自动上报
+INIT_SERVERS = [
+    {'id': 's1', 'ip': '127.0.0.1', 'group': 'L4', 'max': 50, 'status': 'online'},
+    {'id': 's2', 'ip': '127.0.0.1', 'group': 'L7', 'max': 50, 'status': 'online'},
+]
+
+# 各层级对应的攻击方法列表
+LAYER_METHODS = {
+    'L4': ['syn', 'udp'],
+    'L7': ['http', 'https']
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,20 @@
+body {
+  background: #f8f9fa;
+  color: #333;
+  font-family: 'Segoe UI', Arial, sans-serif;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: .5rem;
+}
+
+.navbar {
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.btn-primary {
+  background-color: #0d6efd;
+  border-color: #0d6efd;
+}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <title>管理后台</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="{{ url_for('static', filename='style.css') }}" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-light bg-light justify-content-between px-3">
+  <span class="navbar-brand mb-0 h1">管理后台</span>
+  <div>
+    <a href="{{ url_for('index') }}" class="me-3">提交任务</a>
+    <a href="{{ url_for('task_list') }}" class="me-3">任务列表</a>
+    <a href="{{ url_for('logout') }}">退出</a>
+  </div>
+</nav>
+<div class="container py-4">
+  <button class="btn btn-secondary mb-3" onclick="fetchServers()">刷新</button>
+  <table class="table table-striped" id="srv-table">
+    <thead><tr><th>ID</th><th>IP</th><th>分组</th><th>最大并发</th><th>状态</th><th>操作</th></tr></thead>
+    <tbody></tbody>
+  </table>
+
+  <div class="modal fade" id="editModal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">编辑服务器</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3"><label class="form-label">ID</label><input id="edit-id" class="form-control"></div>
+          <div class="mb-3"><label class="form-label">IP</label><input id="edit-ip" class="form-control"></div>
+          <div class="mb-3"><label class="form-label">类型</label>
+            <select id="edit-group" class="form-select"><option value="L4">L4</option><option value="L7">L7</option></select>
+          </div>
+          <div class="mb-3"><label class="form-label">线程max</label><input id="edit-max" type="number" class="form-control"></div>
+          <div class="mb-3"><label class="form-label">状态</label>
+            <select id="edit-status" class="form-select"><option value="online">online</option><option value="offline">offline</option></select>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">取消</button>
+          <button type="button" class="btn btn-primary" onclick="saveEdit()">保存</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+let srvData=[];
+function fetchServers(){
+  fetch('{{ url_for('api_servers') }}').then(r=>r.json()).then(data=>{
+    srvData = data;
+    const tbody = document.querySelector('#srv-table tbody');
+    tbody.innerHTML='';
+    data.forEach(s=>{
+      const tr=document.createElement('tr');
+      tr.innerHTML=`<td>${s.id}</td><td>${s.ip}</td><td>${s.group}</td><td>${s.max}</td><td>${s.status}</td><td><button class='btn btn-sm btn-outline-primary' onclick="openEdit('${s.id}')">编辑</button></td>`;
+      tbody.appendChild(tr);
+    });
+  });
+}
+let currentId='';
+function openEdit(id){
+  const s=srvData.find(x=>x.id===id);
+  if(!s) return;
+  currentId=id;
+  document.getElementById('edit-id').value=s.id;
+  document.getElementById('edit-ip').value=s.ip;
+  document.getElementById('edit-group').value=s.group;
+  document.getElementById('edit-max').value=s.max;
+  document.getElementById('edit-status').value=s.status;
+  const modal=new bootstrap.Modal(document.getElementById('editModal'));
+  modal.show();
+}
+function saveEdit(){
+  const data={
+    id:document.getElementById('edit-id').value,
+    ip:document.getElementById('edit-ip').value,
+    group:document.getElementById('edit-group').value,
+    max:document.getElementById('edit-max').value,
+    status:document.getElementById('edit-status').value
+  };
+  fetch(`/admin/server/${currentId}/edit`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)}).then(()=>{
+    bootstrap.Modal.getInstance(document.getElementById('editModal')).hide();
+    fetchServers();
+  });
+}
+fetchServers();
+</script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <title>任务提交</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="{{ url_for('static', filename='style.css') }}" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-light bg-light justify-content-between px-3">
+  <span class="navbar-brand mb-0 h1">压力测试平台</span>
+  <div>
+    <a href="{{ url_for('task_list') }}" class="me-3">任务列表</a>
+    {% if role == 'admin' %}<a href="{{ url_for('admin') }}" class="me-3">管理后台</a>{% endif %}
+    <a href="{{ url_for('logout') }}">退出</a>
+  </div>
+</nav>
+<div class="container py-4">
+  {% if message %}<div class="alert alert-info">{{ message }}</div>{% endif %}
+  {% for msg in get_flashed_messages() %}<div class="alert alert-danger">{{ msg }}</div>{% endfor %}
+  <form method="post" class="row g-3">
+    <div class="col-12">
+      <label class="form-label">目标地址（每行一个）</label>
+      <textarea name="targets" class="form-control" rows="4" placeholder="example.com"></textarea>
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">攻击层级</label>
+      <select name="layer" id="layer" class="form-select">
+        <option value="L4">L4</option>
+        <option value="L7">L7</option>
+      </select>
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">并发数：<span id="ccur">1</span></label>
+      <input type="range" name="concurrency" id="concurrency" class="form-range" min="1" max="{{ max_concurrency }}" value="1">
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">时长：<span id="cdur">1</span>s</label>
+      <input type="range" name="duration" id="duration" class="form-range" min="1" max="{{ max_duration }}" value="1">
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">攻击方法</label>
+      <select name="method" id="method" class="form-select"></select>
+    </div>
+    <div class="col-12">
+      <button type="submit" class="btn btn-primary">提交任务</button>
+    </div>
+  </form>
+</div>
+<script>
+const layerMethods = {{ layer_methods|tojson }};
+function updateMethods(){
+  const layer = document.getElementById('layer').value;
+  const msel = document.getElementById('method');
+  msel.innerHTML = '';
+  layerMethods[layer].forEach(m=>{
+    const op = document.createElement('option');
+    op.value = m; op.textContent = m; msel.appendChild(op);
+  });
+}
+updateMethods();
+document.getElementById('layer').addEventListener('change', updateMethods);
+const rngC = document.getElementById('concurrency');
+const spanC = document.getElementById('ccur');
+rngC.addEventListener('input', ()=> spanC.textContent = rngC.value);
+const rngD = document.getElementById('duration');
+const spanD = document.getElementById('cdur');
+rngD.addEventListener('input', ()=> spanD.textContent = rngD.value);
+</script>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <title>登录</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="{{ url_for('static', filename='style.css') }}" rel="stylesheet">
+</head>
+<body class="d-flex align-items-center justify-content-center bg-light" style="height:100vh;">
+  <div class="card p-4 shadow" style="width:100%;max-width:360px;">
+    <h4 class="mb-4 text-center">系统登录</h4>
+    {% if error %}<div class="alert alert-danger text-center p-2">{{ error }}</div>{% endif %}
+    <form method="post">
+      <div class="mb-3">
+        <input type="password" class="form-control" name="password" placeholder="请输入密码" required>
+      </div>
+      <div class="d-grid">
+        <button type="submit" class="btn btn-primary">登录</button>
+      </div>
+    </form>
+  </div>
+</body>
+</html>

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <title>任务进度</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="{{ url_for('static', filename='style.css') }}" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-light bg-light justify-content-between px-3">
+  <span class="navbar-brand mb-0 h1">任务列表</span>
+  <div>
+    <a href="{{ url_for('index') }}" class="me-3">提交任务</a>
+    {% if role == 'admin' %}<a href="{{ url_for('admin') }}" class="me-3">管理后台</a>{% endif %}
+    <a href="{{ url_for('logout') }}">退出</a>
+  </div>
+</nav>
+<div class="container py-4">
+  <div class="mb-2">排队任务：<span id="queue-len">0</span></div>
+  <table class="table table-striped" id="task-table">
+    <thead>
+      <tr>
+        <th>ID</th><th>目标</th><th>层级</th><th>并发</th><th>时长</th><th>方法</th><th>状态</th><th>进度</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+</div>
+<script>
+function fetchTasks(){
+  fetch('{{ url_for('api_tasks') }}').then(r=>r.json()).then(data=>{
+    const tbody = document.querySelector('#task-table tbody');
+    tbody.innerHTML = '';
+    data.forEach(t=>{
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${t.id}</td><td>${t.targets.join('<br>')}</td><td>${t.layer}</td><td>${t.concurrency}</td><td>${t.duration}</td><td>${t.method}</td><td>${t.status}</td><td><div class="progress"><div class="progress-bar" style="width:${t.progress}%">${t.progress}%</div></div></td>`;
+      tbody.appendChild(tr);
+    });
+    const qlen = data.filter(t=>t.status === '排队中').length;
+    document.getElementById('queue-len').textContent = qlen;
+  });
+}
+fetchTasks();
+setInterval(fetchTasks, 3000);
+</script>
+</body>
+</html>

--- a/worker.py
+++ b/worker.py
@@ -1,0 +1,54 @@
+
+from flask import Flask, request, jsonify
+import subprocess
+import os
+import requests
+import threading
+
+app = Flask(__name__)
+
+last_status = "等待任务"
+GO_EXEC = os.environ.get('GO_EXEC', './go_task')
+MANAGER_URL = os.environ.get('MANAGER_URL')
+AGENT_ID = os.environ.get('AGENT_ID', 'agent1')
+AGENT_GROUP = os.environ.get('AGENT_GROUP', 'L4')
+AGENT_MAX = int(os.environ.get('AGENT_MAX', '100'))
+
+def report():
+    if MANAGER_URL:
+        try:
+            requests.post(
+                MANAGER_URL.rstrip('/') + '/agent/register',
+                json={'id': AGENT_ID, 'ip': os.environ.get('AGENT_IP', ''),
+                      'group': AGENT_GROUP, 'max': AGENT_MAX}, timeout=5
+            )
+        except requests.RequestException:
+            pass
+
+@app.route('/task', methods=['POST'])
+def task():
+    global last_status
+    data = request.get_json() or {}
+    link = data.get('link')
+    threads = str(data.get('threads', 1))
+    if not link:
+        last_status = '缺少链接参数'
+        return jsonify({'error': 'missing link'}), 400
+    try:
+        result = subprocess.run([GO_EXEC, link, threads], capture_output=True, text=True, check=True)
+        last_status = result.stdout.strip() or '已完成'
+        return jsonify({'status': 'ok'})
+    except FileNotFoundError:
+        last_status = 'Go 程序不存在'
+        return jsonify({'error': 'go program not found'}), 500
+    except subprocess.CalledProcessError as e:
+        last_status = e.stderr.strip() or '执行失败'
+        return jsonify({'error': 'go program failed'}), 500
+
+@app.route('/status', methods=['GET'])
+def status():
+    return last_status
+
+if __name__ == '__main__':
+    threading.Thread(target=report, daemon=True).start()
+    app.run(host='0.0.0.0', port=8000)


### PR DESCRIPTION
## 总结
- 移除提交页排队提示，任务列表新增排队任务数量统计并实时更新
- 管理后台用“编辑”弹窗修改服务器信息（ID、IP、类型、线程上限、状态），后端新增保存接口
- README 更新说明任务列表排队显示与服务器编辑能力

## 测试
- `pip install -r requirements.txt`
- `python -m py_compile app.py worker.py`
- `python app.py &` 后 `curl -I http://127.0.0.1:5000/login`


------
https://chatgpt.com/codex/tasks/task_e_689054d98e68832baebbde78c1ac74ff